### PR TITLE
Updated RDS security groups

### DIFF
--- a/terraform/phase_one/main.tf
+++ b/terraform/phase_one/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
   secret_key = var.AWS_SECRET_ACCESS_KEY
 }
 
-# S3 bucket for terraform collab
+# S3 bucket for storing terraform.tf file (for team collaboration)  
 resource "aws_s3_bucket" "c19-sales-tracker-s3-state" {
   bucket        = "c19-sales-tracker-s3-state"
   force_destroy = true
@@ -13,16 +13,26 @@ resource "aws_s3_bucket" "c19-sales-tracker-s3-state" {
 # RDS
 resource "aws_security_group" "c19-sales-tracker-db-sg" {
   name        = "c19-sales-tracker-db-sg"
-  description = "Allow inbound traffic to the RDS on port 5432"
+  description = "RDS security group"
   vpc_id      = var.VPC_ID
+}
 
-  ingress {
-    description = "Postgres access from the internet"
-    from_port   = var.DB_PORT
-    to_port     = var.DB_PORT
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
-  }
+resource "aws_vpc_security_group_ingress_rule" "c19-sales-tracker-access-to-db" {
+  security_group_id = aws_security_group.c19-sales-tracker-db-sg.id
+  description       = "Allows internet access inbound to DB for team and assessors"
+
+  ip_protocol = "tcp"
+  to_port     = var.DB_PORT
+  from_port   = var.DB_PORT
+  cidr_ipv4   = "0.0.0.0/0"
+}
+
+resource "aws_vpc_security_group_egress_rule" "c19-sales-tracker-access-from-db" {
+  security_group_id = aws_security_group.c19-sales-tracker-db-sg.id
+  description       = "Allows all traffic outbound from DB"
+
+  ip_protocol = "-1"
+  cidr_ipv4   = "0.0.0.0/0"
 }
 
 resource "aws_db_instance" "c19-sales-tracker-rds" {


### PR DESCRIPTION
# Description 
This is a later change to enhance the RDS terraform code as before I did a quick fix to enable internet access. It would be nice to prevent internet access but for the requirements of this project we need assessors to access the database. 
- Changed the internet access ingress rule to best practice so it's not passed as an argument but a resource instead
- Added egress rule for all outbound traffic from RDS (it is the default but wanted to be explicit) 