### PR TITLE
Removed path call from workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -3,8 +3,12 @@ name: Pylint and Pytest Workflow
 on:
   push:
     branches: [main]
+    paths:
+      - '**.py'
   pull_request:
     branches: [main]
+    paths:
+      - '**.py'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,8 +6,6 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
-  paths:
-    - '**.py'
 
 jobs:
   lint:


### PR DESCRIPTION
# Description
Removed the path call at the start of the workflow as this was causing an error. making the workflow invalid

Closes: #75 

# Type of change
- [x] Bug fix (change which fixes an issue)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# Mentions
@Tristenx @Zephvv @yvonne @b-yacquub @nikki-w