### PR TITLE
[PR] Fixed price history page bugs 

### DIFF
--- a/dashboard/pages/price_history_page.py
+++ b/dashboard/pages/price_history_page.py
@@ -49,6 +49,7 @@ def main():
     df["change_at_date"] = df["change_at"].dt.date
     df["change_at"] = pd.to_datetime(df["change_at"])
     df["new_price"] = pd.to_numeric(df["new_price"])
+    df["desired_price"] = pd.to_numeric(df["desired_price"])
 
     st.divider()
 
@@ -81,7 +82,7 @@ def main():
                 Please check back later!
                 """)
 
-    if not start_date < end_date:
+    if start_date > end_date:
         st.error("Error: End date must fall after start date.")
         return
 
@@ -123,7 +124,7 @@ def main():
             elif current_price < original_price:
                 st.write(f"Current Price: £{current_price} :green[⬇]")
             else:
-                st.write(f"Current Price: £{current_price} -")
+                st.write(f"Current Price: £{current_price} :orange[**–**]")
 
     st.divider()
 


### PR DESCRIPTION
# Description
In the price history page of the dashboard, users who had just subscribed to a product were unable to see the graph due to the end date logic insisting that it be after the start date when in reality it should allow the same day so this PR fixes that 

Changed the visual '–' being in white to bold and orange so it's easier for users to see that it's a symbol for no change in price on the current price KPI box 

Found another small bug where the graph was interpreting the desired price wrong. Eg. for '5' it would plot '50' so needed to convert the data type 

Closes: #195 

# Type of change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# Mentions
@Tristenx @Zephvv @yvonne @b-yacquub @nikki-w