### PR TITLE
Bug steam price bundle

### DIFF
--- a/scraper/steam/extract.py
+++ b/scraper/steam/extract.py
@@ -79,7 +79,8 @@ def scrape_price(html: tuple[int, str], container_class: str) -> str:
     soup = BeautifulSoup(html[1], "html.parser")
     price_container = soup.find(attrs={"class": container_class})
     divs = price_container.find_all("div")
-    return re.search(r"£\d+(?:\.\d{2})?", divs[-2].text.strip()).group()
+    price = re.search(r"£\d+(?:\.\d{2})?", divs[-2].text.strip()).group()
+    return price
 
 
 def get_current_price(url: str, container_class: str, headers: dict[str:str]) -> str:

--- a/scraper/steam/extract.py
+++ b/scraper/steam/extract.py
@@ -10,7 +10,6 @@ from bs4 import BeautifulSoup
 from psycopg2 import connect
 from psycopg2.extensions import connection
 from psycopg2.extras import RealDictCursor
-from lxml import etree
 
 
 def get_db_connection() -> connection:
@@ -74,7 +73,7 @@ def get_html_text(url: str, headers: dict[str:str]) -> tuple[int, str]:
     return res.status_code, res.reason
 
 
-def is_discounted(html: str, discounted_class: str) -> bool:
+def is_discounted(html: tuple[int, str], discounted_class: str) -> bool:
     """Checks if the product price_class is present on the webpage."""
     soup = BeautifulSoup(html[1], "html.parser")
     if soup.find(attrs={"class": discounted_class}) is not None:
@@ -82,7 +81,7 @@ def is_discounted(html: str, discounted_class: str) -> bool:
     return False
 
 
-def scrape_price(html: str, cost_class: str) -> str:
+def scrape_price(html: tuple[int, str], cost_class: str) -> str:
     """Returns the price of a product for the product URL and cost class."""
     soup = BeautifulSoup(html[1], "html.parser")
     price = soup.find(attrs={"class": cost_class}).text.strip()
@@ -100,14 +99,6 @@ def get_current_price(url: str, cost_class: str, discounted_class: str, headers:
     return html_text
 
 
-def scrape_price_xpath(html: str, xpath: str) -> str:
-    """Returns the price of a product for the product URL and cost class."""
-    soup = BeautifulSoup(html[1], "html.parser")
-    price = soup.find(attrs={"class": xpath}).text.strip()
-    if price:
-        return price
-
-
 if __name__ == "__main__":
     user_agent = {
         "User-Agent":
@@ -116,7 +107,8 @@ if __name__ == "__main__":
     }
     steam_cost_class = "game_purchase_price price"
     steam_discounted_class = "discount_final_price"
+    steam_xpath = '//*[@id="game_area_purchase_section_add_to_cart_415372"]/div[2]/div/div[1]/text()'
     html_text = get_html_text(
-        "https://store.steampowered.com/app/1145360/Hades/",
+        "https://store.steampowered.com/app/881100/Noita/",
         user_agent)
-    print(scrape_price_xpath(html_text, steam_cost_class))
+    print(get_current_price(html_text, steam_xpath))

--- a/scraper/steam/extract.py
+++ b/scraper/steam/extract.py
@@ -4,6 +4,7 @@ prices from their respective URLs.
 """
 
 from os import environ
+import re
 
 import requests as req
 from bs4 import BeautifulSoup
@@ -73,42 +74,17 @@ def get_html_text(url: str, headers: dict[str:str]) -> tuple[int, str]:
     return res.status_code, res.reason
 
 
-def is_discounted(html: tuple[int, str], discounted_class: str) -> bool:
-    """Checks if the product price_class is present on the webpage."""
-    soup = BeautifulSoup(html[1], "html.parser")
-    if soup.find(attrs={"class": discounted_class}) is not None:
-        return True
-    return False
-
-
-def scrape_price(html: tuple[int, str], cost_class: str) -> str:
+def scrape_price(html: tuple[int, str], container_class: str) -> str:
     """Returns the price of a product for the product URL and cost class."""
     soup = BeautifulSoup(html[1], "html.parser")
-    price = soup.find(attrs={"class": cost_class}).text.strip()
-    if price:
-        return price
+    price_container = soup.find(attrs={"class": container_class})
+    divs = price_container.find_all("div")
+    return re.search(r"£\d+(?:\.\d{2})?", divs[-2].text.strip()).group()
 
 
-def get_current_price(url: str, cost_class: str, discounted_class: str, headers: dict[str:str]) -> str:
+def get_current_price(url: str, container_class: str, headers: dict[str:str]) -> str:
     """Returns the current price of a product from its details."""
     html_text = get_html_text(url, headers)
     if html_text[0] == 200:
-        if is_discounted(html_text, discounted_class):
-            return scrape_price(html_text, discounted_class)
-        return scrape_price(html_text, cost_class)
+        return scrape_price(html_text, container_class)
     return html_text
-
-
-if __name__ == "__main__":
-    user_agent = {
-        "User-Agent":
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, \
-        like Gecko) Chrome/140.0.0.0 Safari/537.36"
-    }
-    steam_cost_class = "game_purchase_price price"
-    steam_discounted_class = "discount_final_price"
-    steam_xpath = '//*[@id="game_area_purchase_section_add_to_cart_415372"]/div[2]/div/div[1]/text()'
-    html_text = get_html_text(
-        "https://store.steampowered.com/app/881100/Noita/",
-        user_agent)
-    print(get_current_price(html_text, steam_xpath))

--- a/scraper/steam/extract.py
+++ b/scraper/steam/extract.py
@@ -10,6 +10,7 @@ from bs4 import BeautifulSoup
 from psycopg2 import connect
 from psycopg2.extensions import connection
 from psycopg2.extras import RealDictCursor
+from lxml import etree
 
 
 def get_db_connection() -> connection:
@@ -97,3 +98,25 @@ def get_current_price(url: str, cost_class: str, discounted_class: str, headers:
             return scrape_price(html_text, discounted_class)
         return scrape_price(html_text, cost_class)
     return html_text
+
+
+def scrape_price_xpath(html: str, xpath: str) -> str:
+    """Returns the price of a product for the product URL and cost class."""
+    soup = BeautifulSoup(html[1], "html.parser")
+    price = soup.find(attrs={"class": xpath}).text.strip()
+    if price:
+        return price
+
+
+if __name__ == "__main__":
+    user_agent = {
+        "User-Agent":
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, \
+        like Gecko) Chrome/140.0.0.0 Safari/537.36"
+    }
+    steam_cost_class = "game_purchase_price price"
+    steam_discounted_class = "discount_final_price"
+    html_text = get_html_text(
+        "https://store.steampowered.com/app/1145360/Hades/",
+        user_agent)
+    print(scrape_price_xpath(html_text, steam_cost_class))

--- a/scraper/steam/load.py
+++ b/scraper/steam/load.py
@@ -51,14 +51,12 @@ def handler(event=None, context=None) -> dict[str:str]:
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, \
             like Gecko) Chrome/140.0.0.0 Safari/537.36"
     }
-    steam_cost_class = "game_purchase_price price"
-    steam_discounted_class = "discount_final_price"
+    steam_container_class = "game_area_purchase_game"
     db_conn = get_db_connection()
     steam_products = get_products(db_conn)
     last_recorded_prices = get_last_recorded_prices(db_conn)
     steam_products = format_products(steam_products,
-                                     steam_cost_class,
-                                     steam_discounted_class,
+                                     steam_container_class,
                                      user_agent,
                                      last_recorded_prices)
     updated_prices = compare_prices(db_conn, steam_products)

--- a/scraper/steam/requirements.txt
+++ b/scraper/steam/requirements.txt
@@ -4,4 +4,3 @@ requests==2.32.5
 bs4==0.0.2
 psycopg2-binary==2.9.10
 python-dotenv==1.1.1
-lxml==6.0.2

--- a/scraper/steam/requirements.txt
+++ b/scraper/steam/requirements.txt
@@ -1,6 +1,7 @@
-pylint
-pytest
-requests
-bs4
-psycopg2-binary
-python-dotenv
+pylint==3.3.8
+pytest==8.4.2
+requests==2.32.5
+bs4==0.0.2
+psycopg2-binary==2.9.10
+python-dotenv==1.1.1
+lxml==6.0.2

--- a/scraper/steam/test_extract.py
+++ b/scraper/steam/test_extract.py
@@ -3,40 +3,69 @@
 from unittest.mock import patch
 
 from extract import (scrape_price,
-                     is_discounted,
                      get_current_price)
+
+
+HTML = """    <div class="game_area_purchase_game">
+        <div class="game_area_purchase_platform">
+            <span class="platform_img win"></span>
+        </div>
+
+        <div class="game_purchase_action">
+            <div class="game_purchase_action_bg">
+                <div class="game_purchase_price price" data-price-final="4999">
+                    £49.99
+                </div>
+                <div class="btn_addtocart">
+                    <a class="btn_green_steamui btn_medium"
+                    data-panel='{"focusable":true,"clickOnActivate":true}'
+                    href="javascript:addToCart(822363);"
+                    id="btn_add_to_cart_822363"
+                    role="button">
+                        <span>Add to Cart</span>
+                    </a>
+                </div>
+            </div>
+        </div>
+
+        <div class="game_purchase_action_bg">
+            <div class="game_purchase_price price" data-price-final="4999">
+                £49.99
+            </div>
+            <div class="btn_addtocart">
+                <a class="btn_green_steamui btn_medium"
+                data-panel='{"focusable":true,"clickOnActivate":true}'
+                href="javascript:addToCart(822363);"
+                id="btn_add_to_cart_822363"
+                role="button">
+                    <span>Add to Cart</span>
+                </a>
+            </div>
+        </div>
+
+        <div class="game_purchase_price price" data-price-final="4999">
+            £49.99
+        </div>
+
+        <div class="btn_addtocart">
+            <a class="btn_green_steamui btn_medium"
+            data-panel='{"focusable":true,"clickOnActivate":true}'
+            href="javascript:addToCart(822363);"
+            id="btn_add_to_cart_822363"
+            role="button">
+                <span>Add to Cart</span>
+            </a>
+        </div>
+
+        £49.99
+    </div>"""
 
 
 def test_scrape_price():
     """Tests that the scrape function returns the price."""
-    steam_cost_class = "game_purchase_price price"
-    html = (200,
-            "<div class='game_purchase_price price' data-price-final='5999'>£59.99</div>")
-    assert scrape_price(html, steam_cost_class) == '£59.99'
-
-
-def test_scrape_discounted_price():
-    """Tests that the is_discount function works with non none values."""
-    steam_discounted_class = "discount_final_price"
-    html = (200,
-            "<div class='discount_final_price'>£39.99</div>")
-    assert scrape_price(html, steam_discounted_class) == '£39.99'
-
-
-def test_is_discounted_true():
-    """Tests that the is_discount function works with none values."""
-    steam_discounted_class = "discount_final_price"
-    html = (200,
-            "<div class='discount_final_price'>£39.99</div>")
-    assert is_discounted(html, steam_discounted_class) == True
-
-
-def test_is_discounted_false():
-    """Tests that the is_discount function works with none values."""
-    steam_discounted_class = "discount_final_price"
-    html = (200,
-            "<div class='game_purchase_price price' data-price-final='5999'>£59.99</div>")
-    assert is_discounted(html, steam_discounted_class) == False
+    html_tuple = (200, HTML)
+    result = scrape_price(html_tuple, "game_area_purchase_game")
+    assert result == "£49.99"
 
 
 @patch("extract.get_html_text")
@@ -45,24 +74,7 @@ def test_get_current_price_false(mock_html):
     Tests that the functions work together to get the price of the product 
     if discount is false.
     """
-    mock_html.return_value = (200,
-                              "<div class='game_purchase_price price' data-price-final='5999'>£59.99</div>")
-    steam_cost_class = "game_purchase_price price"
-    steam_discounted_class = "discount_final_price"
-    result = '£59.99'
-
-    assert get_current_price("fake_http", steam_cost_class, steam_discounted_class, {
-                             "User-Agent": "test"}) == result
-
-
-@patch("extract.get_html_text")
-def test_get_current_price(mock_html):
-    """Tests that the functions work together to get the price of the product if discount is true."""
-    mock_html.return_value = (200,
-                              "<div class='discount_final_price'>£39.99</div>")
-    steam_cost_class = "game_purchase_price price"
-    steam_discounted_class = "discount_final_price"
-    result = '£39.99'
-
-    assert get_current_price("fake_http", steam_cost_class, steam_discounted_class, {
-                             "User-Agent": "test"}) == result
+    mock_html.return_value = (200, HTML)
+    result = get_current_price("fake_http", "game_area_purchase_game", {
+        "User-Agent": "test"})
+    assert result == "£49.99"

--- a/scraper/steam/transform.py
+++ b/scraper/steam/transform.py
@@ -27,8 +27,9 @@ def create_id_price_map(rows: list[dict]) -> dict[int:float]:
     return price_map
 
 
-def format_products(products: dict[str:str], cost_class: str,
-                    discounted_class: str, headers: dict[str:str],
+def format_products(products: dict[str:str],
+                    container_class: str,
+                    headers: dict[str:str],
                     recorded_prices: list[dict]) -> dict[str:str]:
     """
     Adds the current price, price in database, and
@@ -39,8 +40,7 @@ def format_products(products: dict[str:str], cost_class: str,
     for product in products:
         product["price"] = convert_string_price_to_float(
             get_current_price(product["product_url"],
-                              cost_class,
-                              discounted_class,
+                              container_class,
                               headers))
         if product["product_id"] not in tracked_ids:
             product["db_price"] = "NEW"


### PR DESCRIPTION
# Improved Scrape Price

# Description
I've changed how the price is scraped using the scrape_price function. It now targets the container of the price and uses regex to extract the current price. This fixes the bug where steam bundle sales took priority over the actual product price. As I've altered the scrape_price function tests needed to be changed and the scripts which used this function have been updated accordingly. I also added version numbers to requirements.txt.

Closes: #192 

# Type of change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# Mentions
@Tristenx @Zephvv @yvonne @b-yacquub @nikki-w