### PR TITLE
[PR] Sign up form no longer clears on entry

### DIFF
--- a/dashboard/login.py
+++ b/dashboard/login.py
@@ -19,7 +19,7 @@ def sign_up_form() -> None:
     st.set_page_config(page_title="Souper Saver Login",
                        layout="centered", initial_sidebar_state="collapsed")
 
-    with st.form("Sign up", clear_on_submit=True):
+    with st.form("Sign up", clear_on_submit=False):
         st.subheader("Please create an account to get access to Souper Saver!")
         username = st.text_input("Please create a username", key="username")
         new_email_input = st.text_input(


### PR DESCRIPTION
# Description
Altered the sign up form so it no longer clears on entery to prevent users having to reinput their details if they miss an input box when signing up.

Closes: #249 

# Type of change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# Mentions
@Tristenx @Zephvv @yvonne @b-yacquub @nikki-w