### PR TITLE
[PR] Added delay to success message in tracking page

### DIFF
--- a/dashboard/pages/currently_tracking.py
+++ b/dashboard/pages/currently_tracking.py
@@ -1,5 +1,6 @@
 """Currently tracking page that displays all products currently tracked for a user."""
 
+import time
 import datetime as datetime
 
 import streamlit as st
@@ -135,6 +136,7 @@ def main():
                     # delete id from subscription table
                     delete_subscription(conn, subscription_id)
                     st.success(f"Stopped tracking {product['product_name']}.")
+                    time.sleep(2)
                     st.rerun()
 
     conn.close()


### PR DESCRIPTION
# Description
Added a delay using `time.sleep()` so that the user should now have enough time to read the success message given when a product has been removed from their tracking list.

Closes: #256 

# Type of change
- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# Mentions
@Tristenx @Zephvv @yvonne @b-yacquub @nikki-w